### PR TITLE
Forbedrer feilhåndtering hvis strangler ikke svarer som den skal

### DIFF
--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -29,8 +29,8 @@ import kotlinx.coroutines.runBlocking
 import no.nav.syfo.api.registerNaisApi
 import no.nav.syfo.forskuttering.ForskutteringsClient
 import no.nav.syfo.forskuttering.registrerForskutteringApi
-import no.nav.syfo.narmesteLederApi.NarmesteLederClient
-import no.nav.syfo.narmesteLederApi.registrerNarmesteLederApi
+import no.nav.syfo.narmestelederapi.NarmesteLederClient
+import no.nav.syfo.narmestelederapi.registrerNarmesteLederApi
 import org.apache.http.impl.conn.SystemDefaultRoutePlanner
 import org.slf4j.LoggerFactory
 import java.net.ProxySelector

--- a/src/main/kotlin/no/nav/syfo/forskuttering/ForskutteringApi.kt
+++ b/src/main/kotlin/no/nav/syfo/forskuttering/ForskutteringApi.kt
@@ -25,8 +25,8 @@ fun Route.registrerForskutteringApi(forskutteringsClient: ForskutteringsClient) 
 
                 log.info("Mottatt forespørsel om forskuttering for aktør {} og orgnummer {}", aktorId, orgnummer)
 
-                val arbeidsgiverForskutterer = forskutteringsClient.hentNarmesteLederFraSyfoserviceStrangler(aktorId, orgnummer)
-                call.respond(arbeidsgiverForskutterer)
+                val arbeidsgiverForskutterer = forskutteringsClient.hentForskutteringFraSyfoserviceStrangler(aktorId, orgnummer)
+                call.respond(arbeidsgiverForskutterer!!)
 
             } catch (e: IllegalArgumentException) {
                 log.warn("Kan ikke hente forskuttering: {}", e.message)

--- a/src/main/kotlin/no/nav/syfo/forskuttering/ForskutteringClient.kt
+++ b/src/main/kotlin/no/nav/syfo/forskuttering/ForskutteringClient.kt
@@ -15,9 +15,9 @@ class ForskutteringsClient(
         private val accessTokenClient: AccessTokenClient,
         private val client: HttpClient
 ) {
-    suspend fun hentNarmesteLederFraSyfoserviceStrangler(aktorId: String, orgnummer: String): ForskutteringRespons {
+    suspend fun hentForskutteringFraSyfoserviceStrangler(aktorId: String, orgnummer: String): ForskutteringRespons? {
         val accessToken = accessTokenClient.hentAccessToken(resourceId)
-        return client.get("$endpointUrl/api/$aktorId/forskuttering") {
+        return client.get<ForskutteringRespons?>("$endpointUrl/api/$aktorId/forskuttering") {
             accept(ContentType.Application.Json)
             headers {
                 append("Authorization", "Bearer $accessToken")
@@ -25,6 +25,10 @@ class ForskutteringsClient(
                 append("Nav-Callid", MDC.get("Nav-Callid"))
             }
             parameter("orgnummer", orgnummer)
+        }.also {
+            if (it == null) {
+                log.warn("Kunne ikke hente forskuttering for aktorId {} i organisasjon {}", aktorId, orgnummer)
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/narmestelederapi/NarmesteLederApi.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederapi/NarmesteLederApi.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.narmesteLederApi
+package no.nav.syfo.narmestelederapi
 
 import io.ktor.application.call
 import io.ktor.http.HttpStatusCode
@@ -38,7 +38,7 @@ fun Route.registrerNarmesteLederApi(narmesteLederClient: NarmesteLederClient) {
                         ?: throw NotImplementedError("Spørring uten orgnummer er ikke implementert")
 
                 call.respond(narmesteLederClient
-                        .hentNarmesteLederForSykmeldtFraSyfoserviceStrangler(sykmeldtAktorId, orgnummer))
+                        .hentNarmesteLederForSykmeldtFraSyfoserviceStrangler(sykmeldtAktorId, orgnummer)!!)
 
             } catch (e: IllegalArgumentException) {
                 log.warn("Kan ikke hente nærmeste leder da aktørid mangler: {}", e.message)

--- a/src/main/kotlin/no/nav/syfo/narmestelederapi/NarmesteLederClient.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederapi/NarmesteLederClient.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.narmesteLederApi
+package no.nav.syfo.narmestelederapi
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.accept
@@ -38,16 +38,20 @@ class NarmesteLederClient(
         }
     }
 
-    suspend fun hentNarmesteLederForSykmeldtFraSyfoserviceStrangler(sykmeldtAktorId: String, orgnummer: String): NarmesteLederRelasjon {
+    suspend fun hentNarmesteLederForSykmeldtFraSyfoserviceStrangler(sykmeldtAktorId: String, orgnummer: String): NarmesteLederRelasjon? {
         val accessToken = accessTokenClient.hentAccessToken(resourceId)
-        return client.get<NarmesteLeder>("$endpointUrl/sykmeldt/$sykmeldtAktorId/narmesteleder?orgnummer=$orgnummer") {
+        return client.get<NarmesteLeder?>("$endpointUrl/sykmeldt/$sykmeldtAktorId/narmesteleder?orgnummer=$orgnummer") {
             accept(ContentType.Application.Json)
             headers {
                 append("Authorization", "Bearer $accessToken")
                 append("Nav-Consumer-Id", MDC.get("Nav-Consumer-Id"))
                 append("Nav-Callid", MDC.get("Nav-Callid"))
             }
-        }.let {
+        }.also {
+            if (it == null) {
+                log.warn("Kunne ikke hente nærmeste leder for sykmeldt {} i organisasjon {}", sykmeldtAktorId, orgnummer)
+            }
+        }?.let {
             NarmesteLederRelasjon(
                     aktorId = it.aktorId,
                     orgnummer = it.orgnummer,

--- a/src/main/kotlin/no/nav/syfo/narmestelederapi/NarmesteLederRelasjon.kt
+++ b/src/main/kotlin/no/nav/syfo/narmestelederapi/NarmesteLederRelasjon.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.narmesteLederApi
+package no.nav.syfo.narmestelederapi
 
 import java.time.LocalDate
 

--- a/src/test/kotlin/no/nav/syfo/forskuttering/ForskutteringApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/forskuttering/ForskutteringApiSpek.kt
@@ -21,7 +21,6 @@ import no.nav.syfo.AccessTokenClient
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.getEnvironment
 import no.nav.syfo.initRouting
-import no.nav.syfo.narmesteLederApi.NarmesteLederClient
 import org.amshove.kluent.shouldEqual
 import org.amshove.kluent.shouldMatch
 import org.amshove.kluent.shouldNotEqual


### PR DESCRIPTION
Hvis det mangler data eller det oppstår en feil som gjør at syfostrangler returnerer tomt svar, så vil vi at dette skal håndteres og logges i syfonarmesteleder. 